### PR TITLE
Remove debugging code from the package

### DIFF
--- a/src/components/FormWizard.vue
+++ b/src/components/FormWizard.vue
@@ -239,7 +239,6 @@
         /* const index = this.$.slots.default().length -1  *///fix this part later
         const index = this.tabCount
         item.tabId = `${item.title.replace(/ /g, '')}${index}`
-        console.log(item)
         this.tabs.splice(index, 0, item)
         // if a step is added before the current one, go to it
         if (index < this.activeTabIndex + 1) {


### PR DESCRIPTION
It's a best practice to remove console.log statements (and other debugging code) from a codebase. This will help us not pollute our console with information that is not useful to 99% of people using this package.