### PR TITLE
fix decentered progress bar at step-sizes < 'md'

### DIFF
--- a/src/assets/form-wizard/mixins/_wizard-size.scss
+++ b/src/assets/form-wizard/mixins/_wizard-size.scss
@@ -1,5 +1,5 @@
 @mixin wizard-size($name, $size, $font-size){
-  $computed-font-size: math($size,2) + 5px;
+  $computed-font-size: $size/2 + 5px;
 
   &.#{$name}{
     .wizard-icon-circle{


### PR DESCRIPTION
The original $computed-font-size definition is rendered into invalid CSS and produces decentered progress bar.
```css
.vue-form-wizard.xs .wizard-navigation .wizard-progress-with-circle {
    position: relative;
    top: math(40px,2)5px;
    height: 4px;
}
```