### PR TITLE
improve types export

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "exports": {
     ".": {
       "import": "./dist/vue3-form-wizard.es.js",
-      "require": "./dist/vue3-form-wizard.umd.js"
+      "require": "./dist/vue3-form-wizard.umd.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./dist/style.css": "./dist/style.css"
   },
   "type": "module",
-  "types": "./dist/types/index.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "vite build && vue-tsc  --emitDeclarationOnly",


### PR DESCRIPTION
While using this repo, I had some trouble using types definition with TypeScript. This causes my TS compilation and my pipeline to fail. I found a solution to fix types exports of this library by moving "types" key in package.json in "exports" (tested in my node_modules)